### PR TITLE
Grid from ground

### DIFF
--- a/include/earthquake_system.hpp
+++ b/include/earthquake_system.hpp
@@ -21,9 +21,9 @@ public:
 	EarthquakeSystem(
 		unsigned int width,
 		unsigned int height,
+		unsigned int init_ground_level,
 		unsigned int magnitude_x = 1,
-		unsigned int magnitude_y = 1,
-		int init_ground_level = 40
+		unsigned int magnitude_y = 1
 	) :
 		run_time_(0),
 		ground_dx_(0),

--- a/include/earthquake_system.hpp
+++ b/include/earthquake_system.hpp
@@ -35,7 +35,7 @@ public:
 		assert(magnitude_y_ <= MAGNITUDE_UPPER_BOUND);
 	}
 
-	physics::Particle<T>* particle_near(T x, T y, T radius = 1) {
+	physics::Particle<T>* particle_near(T x, T y, T radius = 1){
 		return system_.particle_near(x, y, radius);
 	}
 

--- a/include/game_state_controller.hpp
+++ b/include/game_state_controller.hpp
@@ -78,11 +78,12 @@ namespace game {
                     }
                     else if (!simulation_running) {
                         // Insertion mode
-                        // Snap to the nearest 20x20 grid point
+                        // Snap to the nearest 20x20 grid point from the ground up
+                        int y_snap = static_cast<int>(earthquake_system.ground_height()) - 40;
                         if(x % 20 < 10)  x -= x % 20;
                         else             x += 20 - x % 20;
-                        if(y % 20 < 10)  y -= y % 20;
-                        else             y += 20 - y % 20;
+                        if((y - y_snap) % 20 < 10)  y -= (y - y_snap) % 20;
+                        else             y += 20 - (y - y_snap) % 20;
 
                         Particle* p = earthquake_system.particle_near(x, y, 10);
                         switch(insertion_mode){

--- a/include/game_state_controller.hpp
+++ b/include/game_state_controller.hpp
@@ -78,6 +78,8 @@ namespace game {
                     }
                     else if (!simulation_running) {
                         // Insertion mode
+                        Particle* p = earthquake_system.particle_near(x, y, 5);
+
                         // Snap to the nearest 20x20 grid point from the ground up
                         int y_snap = static_cast<int>(earthquake_system.ground_height()) - 40;
                         if(x % 20 < 10)  x -= x % 20;
@@ -85,7 +87,6 @@ namespace game {
                         if((y - y_snap) % 20 < 10)  y -= (y - y_snap) % 20;
                         else             y += 20 - (y - y_snap) % 20;
 
-                        Particle* p = earthquake_system.particle_near(x, y, 10);
                         switch(insertion_mode){
                             case insertion_mode_t::PARTICLE:
                                 if (!p) {

--- a/include/game_state_controller.hpp
+++ b/include/game_state_controller.hpp
@@ -82,10 +82,10 @@ namespace game {
 
                         // Snap to the nearest 20x20 grid point from the ground up
                         int y_snap = static_cast<int>(earthquake_system.ground_height()) - INIT_GROUND_LEVEL;
-                        if(x % 20 < 10)  x -= x % 20;
-                        else             x += 20 - x % 20;
+                        if(x % 20 < 10)             x -= x % 20;
+                        else                        x += 20 - x % 20;
                         if((y - y_snap) % 20 < 10)  y -= (y - y_snap) % 20;
-                        else             y += 20 - (y - y_snap) % 20;
+                        else                        y += 20 - (y - y_snap) % 20;
 
                         switch(insertion_mode){
                             case insertion_mode_t::PARTICLE:

--- a/include/game_state_controller.hpp
+++ b/include/game_state_controller.hpp
@@ -81,7 +81,7 @@ namespace game {
                         Particle* p = earthquake_system.particle_near(x, y, 5);
 
                         // Snap to the nearest 20x20 grid point from the ground up
-                        int y_snap = static_cast<int>(earthquake_system.ground_height()) - 40;
+                        int y_snap = static_cast<int>(earthquake_system.ground_height()) - INIT_GROUND_LEVEL;
                         if(x % 20 < 10)  x -= x % 20;
                         else             x += 20 - x % 20;
                         if((y - y_snap) % 20 < 10)  y -= (y - y_snap) % 20;
@@ -178,5 +178,5 @@ namespace game {
     bool GameStateController::simulation_running = false;
     UIController GameStateController::ui_controller = UIController();
     FontController UIController::font_controller = FontController();
-    EarthquakeSystem<float> GameStateController::earthquake_system = EarthquakeSystem<float>(WIDTH, HEIGHT);
+    EarthquakeSystem<float> GameStateController::earthquake_system = EarthquakeSystem<float>(WIDTH, HEIGHT, INIT_GROUND_LEVEL);
 }

--- a/include/game_state_controller.hpp
+++ b/include/game_state_controller.hpp
@@ -78,7 +78,7 @@ namespace game {
                     }
                     else if (!simulation_running) {
                         // Insertion mode
-                        Particle* p = earthquake_system.particle_near(x, y, 5);
+                        Particle* p = earthquake_system.particle_near(x, y, 10);
 
                         // Snap to the nearest 20x20 grid point from the ground up
                         int y_snap = static_cast<int>(earthquake_system.ground_height()) - INIT_GROUND_LEVEL;

--- a/include/ui_controller.hpp
+++ b/include/ui_controller.hpp
@@ -100,12 +100,14 @@ namespace game {
                     glBegin(GL_LINES);
                     glColor4f(0.33f, 0.2f, 0.33f, 0.25f);
 
+                    // vertical lines
                     for (int i = 0; i < WIDTH; i += 20) {
                         glVertex2f(i, 0);
                         glVertex2f(i, HEIGHT);
                     }
 
-                    for (int i = 0; i < HEIGHT; i += 20) {
+                    // horizontal lines
+                    for (float i = ground_height; i < HEIGHT; i += 20) {
                         glVertex2f(0, i);
                         glVertex2f(WIDTH, i);
                     }

--- a/include/ui_controller.hpp
+++ b/include/ui_controller.hpp
@@ -19,6 +19,7 @@ namespace game {
     #define WIDTH 640
     #define HEIGHT 480
     #define FPS 60
+    #define INIT_GROUND_LEVEL 40
 
     enum class insertion_mode_t {
         PARTICLE,

--- a/include/ui_controller.hpp
+++ b/include/ui_controller.hpp
@@ -79,7 +79,8 @@ namespace game {
                         unsigned int horizontal_magnitude,
                         unsigned int vertical_magnitude,
                         float ground_height,
-                        float ground_dx) {
+                        float ground_dx,
+                        std::string timer) {
 
                 glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);             
                 glMatrixMode(GL_PROJECTION);
@@ -130,12 +131,13 @@ namespace game {
                     }
                     font_controller.glPrint(WIDTH-180, HEIGHT-40, "Paused");
                 }
-                else {
-                    font_controller.glPrint(WIDTH-180, HEIGHT-40, "Running");
+
+                // Draw Menu (Start, stop, timer) in the top right of the window
+                if (running) {
+                    glColor3f(1.0f, 1.0f, 1.0f);
+                    font_controller.glPrint(WIDTH-200, HEIGHT-40, timer.c_str());
                 }
-
-                // Draw Menu (Start and stop buttons) in the top right of the window
-
+                
                 // Set color to green
                 glColor3f(0.0f, 1.0f, 0.0f);
                 // Draw start button


### PR DESCRIPTION
This PR moves the snapping grid to always start at ground level. Previously we were not doing that.